### PR TITLE
Update to Daffodil's TDML lib 2.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ project/errors
 .\#*
 .\#.*
 /out/
+/bin/

--- a/build.sbt
+++ b/build.sbt
@@ -4,20 +4,23 @@ organization := "io.github.openDFDL"
  
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.11"
  
 parallelExecution in Test := false
 
 testOptions in ThisBuild += Tests.Argument(TestFrameworks.JUnit, "-v")
 
-crossScalaVersions := Seq("2.12.6", "2.11.12")
+crossScalaVersions := Seq("2.12.11", "2.11.12")
 
 libraryDependencies in ThisBuild := Seq(
   "junit" % "junit" % "4.11" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
-  "org.apache.daffodil" %% "daffodil-tdml-lib" % "latest.integration"
+  "org.apache.daffodil" %% "daffodil-tdml-lib" % "2.6.0",
+  "org.scala-lang.modules" %% "scala-xml" % "1.1.0"
 )
 
+useCoursier := false
 
+retrieveManaged := true
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,19 +8,19 @@ scalaVersion := "2.12.11"
  
 parallelExecution in Test := false
 
-testOptions in ThisBuild += Tests.Argument(TestFrameworks.JUnit, "-v")
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
 
 crossScalaVersions := Seq("2.12.11", "2.11.12")
 
-libraryDependencies in ThisBuild := Seq(
+libraryDependencies := Seq(
   "junit" % "junit" % "4.11" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "org.apache.daffodil" %% "daffodil-tdml-lib" % "2.6.0",
   "org.scala-lang.modules" %% "scala-xml" % "1.1.0"
 )
 
+excludeDependencies += "com.ibm.icu" % "icu4j"
+
 useCoursier := false
 
 retrieveManaged := true
-
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.3.9


### PR DESCRIPTION
This involves implementing the "withXYZZY" methods, and leaving the
deprecated setters (which aren't called) mostly as stubs. 

This version now requires Daffodil 2.6.0 or higher.