### PR TITLE
Fix XML CRLF to LF, and root namespace negative parse test issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Similar cross testers can be created for other DFDL implementations as well.
 Requirements
 
 * IBM DFDL - Note that a developer edition is available. 
-* Daffodil - Version 2.3.0 
+* Daffodil - Version 2.3.0
+
+Note that Daffodil 3.1.0-SNAPSHOT git hash xyzzy or later are necessary for
+TDML parser negative test cases to work properly. Many DFDL schemas do not have
+such tests and will work with older revisions of Daffodil back to 2.3.0.  
 
 How to Install
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "ibm-tdml-processor"
  
 organization := "io.github.openDFDL"
  
-version := "0.1.0-SNAPSHOT"
+version := "1.0.0-SNAPSHOT"
 
 scalaVersion := "2.12.11"
  
@@ -10,13 +10,14 @@ parallelExecution in Test := false
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
 
-crossScalaVersions := Seq("2.12.11", "2.11.12")
+crossScalaVersions := Seq("2.12.11")
 
 libraryDependencies := Seq(
-  "junit" % "junit" % "4.12" % "test",
+  "junit" % "junit" % "4.13.1" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
-  "org.apache.daffodil" %% "daffodil-tdml-lib" % "2.6.0",
-  "org.scala-lang.modules" %% "scala-xml" % "1.1.0"
+  "org.apache.daffodil" %% "daffodil-tdml-lib" % "3.1.0-SNAPSHOT",
+  "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
+  "javax.xml.bind" % "jaxb-api" % "2.3.1"
 )
 
 excludeDependencies += "com.ibm.icu" % "icu4j"

--- a/src/main/java/com/ibm/dfdl/sample/sax/reader/DFDLToSAXEventAdapter1.java
+++ b/src/main/java/com/ibm/dfdl/sample/sax/reader/DFDLToSAXEventAdapter1.java
@@ -31,7 +31,8 @@ public class DFDLToSAXEventAdapter1 extends DFDLToSAXEventAdapter {
 	@Override
 	public void elementValue(String value, DFDLSchemaType baseSchemaType) throws DFDLUserException {
 		StringBuilder sb = new StringBuilder();
-		String escapedValue = XMLUtils.escape(value, sb).toString();
+		String valueWithCRLFsToLFAndPUAs = XMLUtils.remapXMLIllegalCharactersToPUA(value);
+		String escapedValue = XMLUtils.escape(valueWithCRLFsToLFAndPUAs, sb).toString();
 		super.elementValue(escapedValue, baseSchemaType);
 	}
 	

--- a/src/test/resources/crossTestRigTestSchema.dfdl.xsd
+++ b/src/test/resources/crossTestRigTestSchema.dfdl.xsd
@@ -14,5 +14,7 @@
   </xs:annotation>
 
   <xs:element name="r" ibmDfdlExtn:docRoot="true" type="xs:string" dfdl:lengthKind="delimited"/>
-  
+
+  <xs:element name="i" ibmDfdlExtn:docRoot="true" type="xs:int" dfdl:lengthKind="delimited"/>
+
 </xs:schema>

--- a/src/test/resources/crossTestRigTests.tdml
+++ b/src/test/resources/crossTestRigTests.tdml
@@ -52,29 +52,36 @@
     </tdml:infoset>
   </tdml:unparserTestCase>
 
-  <tdml:defineSchema name="twoPass">
-    <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
-    <dfdl:format ref="ex:GeneralFormat" encodingErrorPolicy="error" />
-    <xs:element name="r" dfdl:lengthKind="implicit">
-      <xs:complexType>
-        <xs:sequence dfdl:separator="; ,">
-          <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited" />
-          <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited" />
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
-  </tdml:defineSchema>
+  <tdml:parserTestCase name="ptest1-neg" root="i" model="crossTestRigTestSchema.dfdl.xsd" >
+    <tdml:document>foo</tdml:document>
+    <tdml:errors>
+      <tdml:error>foo</tdml:error>
+    </tdml:errors>
+ </tdml:parserTestCase>
 
-  <tdml:parserTestCase name="testTwoPass" root="r" model="twoPass" roundTrip="twoPass">
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:r>
-          <foo>foo</foo>
-          <bar>bar</bar>
-        </ex:r>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-    <tdml:document>foo,bar</tdml:document>
-  </tdml:parserTestCase>
+ <tdml:defineSchema name="twoPass">
+   <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+   <dfdl:format ref="ex:GeneralFormat" encodingErrorPolicy="error" />
+   <xs:element name="r" dfdl:lengthKind="implicit">
+     <xs:complexType>
+       <xs:sequence dfdl:separator="; ,">
+         <xs:element name="foo" type="xs:string" dfdl:lengthKind="delimited" />
+         <xs:element name="bar" type="xs:string" dfdl:lengthKind="delimited" />
+       </xs:sequence>
+     </xs:complexType>
+   </xs:element>
+ </tdml:defineSchema>
+
+ <tdml:parserTestCase name="testTwoPass" root="r" model="twoPass" roundTrip="twoPass">
+   <tdml:infoset>
+     <tdml:dfdlInfoset>
+       <ex:r>
+         <foo>foo</foo>
+         <bar>bar</bar>
+       </ex:r>
+     </tdml:dfdlInfoset>
+   </tdml:infoset>
+   <tdml:document>foo,bar</tdml:document>
+ </tdml:parserTestCase>
 
 </tdml:testSuite>

--- a/src/test/scala/io/github/openDFDL/TestCrossTestRig.scala
+++ b/src/test/scala/io/github/openDFDL/TestCrossTestRig.scala
@@ -17,7 +17,7 @@
 
 package io.github.openDFDL
 
-import org.apache.daffodil.tdml.{ DFDLTestSuite, Runner }
+import org.apache.daffodil.tdml.Runner
 import org.junit.Test
 
 object TestCrossTestRig {
@@ -36,5 +36,7 @@ class TestCrossTestRig {
   @Test def testIBMTDML_utest1() { runner.runOneTest("utest1") }
 
   @Test def testIBMTDML_twoPass() { runner.runOneTest("testTwoPass") }
+
+  @Test def testIBMTDML_ptest1_neg() { runner.runOneTest("ptest1-neg") }
 
 }


### PR DESCRIPTION
Fixes #10 and #11.

This enables vcard to work with the cross tester (a negative test wouldn't work before).
A similar test was added to the self-tests of this test rig.

Also by converting CRLF to LF when constructing actual XML from the DFDL infoset, this works similarly now to daffodil, which makes tests that use input data containing CRLF portable. 

This requires the fix to https://issues.apache.org/jira/browse/DAFFODIL-2440 which is 
https://github.com/apache/incubator-daffodil/pull/458