### PR TITLE
Update dependencies and packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val processor = (project in file("processor"))
     // The plugin will provide all other dependencies.
     libraryDependencies ++= Seq(
       "javax.xml.bind" % "jaxb-api" % "2.3.1" % "provided",
-      "org.apache.daffodil" %% "daffodil-tdml-processor" % daffodilVersion.value % "provided"
+      "org.apache.daffodil" %% "daffodil-tdml-lib" % daffodilVersion.value % "provided"
     ),
     unmanagedBase := baseDirectory.value.getParentFile / "ibm-dfdl" / "lib",
     Test / unmanagedResourceDirectories += baseDirectory.value.getParentFile / "ibm-dfdl" / "src" / "test" / "resources",

--- a/plugin/src/main/scala/io/github/openDFDL/IBMDFDLPlugin.scala
+++ b/plugin/src/main/scala/io/github/openDFDL/IBMDFDLPlugin.scala
@@ -26,14 +26,14 @@ object IBMDFDLPlugin extends AutoPlugin {
       Defaults.testSettings ++ Seq(
         sourceDirectory := (Test / sourceDirectory).value,
         sources := (Test / sources).value,
-        dependencyClasspath := (dependencyClasspath.value).filterNot { _.data.name.startsWith("icu4j")},
+        dependencyClasspath := (dependencyClasspath.value).filterNot { _.data.name.startsWith("daffodil-tdml-processor")},
+        dependencyClasspath := (dependencyClasspath.value).filterNot { _.data.name.startsWith("icu4j")}
       )
     ) ++
     Seq(
       libraryDependencies ++= Seq(
-        "junit" % "junit" % "4.13.2" % IbmConfig.name,
-        "com.github.sbt" % "junit-interface" % "0.13.3" % IbmConfig.name,
-        "io.github.openDFDL" % "ibm-tdml-processor" % sbtIbmDfdlPluginVersion % s"${IbmConfig.name}->compile"
+        "javax.xml.bind" % "jaxb-api" % "2.3.1" % IbmConfig.name,
+        "io.github.openDFDL" % "ibm-tdml-processor" % sbtIbmDfdlPluginVersion % IbmConfig.name
       ),
       ibmTest := (IbmConfig / test).value
     )

--- a/processor/src/main/scala/org/apache/daffodil/processor/tdml/IBM_DFDL.scala
+++ b/processor/src/main/scala/org/apache/daffodil/processor/tdml/IBM_DFDL.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.daffodil.tdml.processor
+package org.apache.daffodil.processor.tdml
 
 import com.ibm.dfdl.grammar.DFDLGrammarFactory
 import com.ibm.dfdl.grammar.IDFDLGrammar
@@ -43,7 +43,6 @@ import org.apache.daffodil.lib.iapi.URISchemaSource
 import org.apache.daffodil.lib.util.Maybe
 import org.apache.daffodil.lib.xml.DFDLCatalogResolver
 import org.apache.daffodil.lib.xml.XMLUtils
-import org.apache.daffodil.processor.tdml._
 import org.apache.daffodil.tdml.TDMLTestNotCompatibleException
 import org.apache.daffodil.tdml.processor.*
 import org.xml.sax.ErrorHandler


### PR DESCRIPTION
- Replace `daffodil-tdml-processor` with `daffodil-tdml-lib` in `build.sbt`
- Adjust relevant import and dependency configurations.